### PR TITLE
Only use whitelisted timezones

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_custom_command(
 		${CMAKE_SOURCE_DIR}/src/gen-ext-timezones.py
 		-s ${CMAKE_SOURCE_DIR}/src
 		-o ext-timezones.json
+		-w
 	DEPENDS src/gen-ext-timezones.py
 	        src/mccInfo.json
 	        src/uiTzInfo.json


### PR DESCRIPTION
To make sure we only use proper timezones and don't end up with the incorrectly guessed timezone descriptions like "Myanmar Time" for some US cities.
