### PR TITLE
Added default keyboardSize partial fix for #995

### DIFF
--- a/files/conf/defaultPreferences.txt
+++ b/files/conf/defaultPreferences.txt
@@ -45,7 +45,8 @@
 				"autoCompletion": false,
 				"predictiveText": false,
 				"spellChecking": false,
-				"keyPressFeedback": false
+				"keyPressFeedback": false,
+				"keyboardSize": "M"
 		}
 	}
 }


### PR DESCRIPTION
Currently keyboard size isn't stored, we need to set an initial value ("XS", "S", "M" or "L"). Legacy uses "M" equivalent as initial value. We need to adjust webos-keyboard as well to pick this value up and store it in case it changes. This is a partial fix for bug #995
