### PR TITLE
luna-init: Add launcher & dock configuration

### DIFF
--- a/files/conf/default-dock-positions.json
+++ b/files/conf/default-dock-positions.json
@@ -1,9 +1,21 @@
-{
-    "quicklauncher": [
-        "org.webosports.app.browser_default",
-        "com.palm.app.email_default",
-        "com.palm.app.calendar_default",
-        "org.webosports.app.messaging_default",
-        "org.webosports.app.photos_default" 
-    ]
-}
+[
+	{
+		"type": "tablet",
+		"items": [
+				"org.webosports.app.browser_default",
+				"com.palm.app.email_default",
+				"com.palm.app.calendar_default",
+				"org.webosports.app.messaging_default",
+				"org.webosports.app.memos_default" 
+			]
+	},
+	{
+		"type": "phone",
+		"items": [
+			"org.webosports.app.phone_default",
+			"org.webosports.app.messaging_default",
+			"com.palm.app.email_default",
+			"com.palm.app.calendar_default"
+		]
+	}
+]

--- a/files/conf/default-launcher-page-layout.json
+++ b/files/conf/default-launcher-page-layout.json
@@ -1,0 +1,69 @@
+[
+    {
+        "title" : "apps",
+        "items" : [
+            "org.webosports.app.browser_default",
+            "com.palm.app.email_default",
+            "com.palm.app.calendar_default",
+            "org.webosports.app.messaging_default",
+            "org.webosports.app.memos_default",
+            "org.webosports.app.maps_default",
+            "org.webosports.app.contacts_default",
+            "org.webosports.app.phone_default",
+            "com.palm.app.musicplayer_default",
+            "com.palm.app.photos_default",
+            "com.palm.app.enyo-facebook_default",
+            "com.palm.app.youtube_default",
+            "com.palm.app.kindle_default",
+            "com.palm.app.amazonmp3_default"
+        ] 
+    },
+    {
+        "title" : "downloads",
+        "items" : [
+            "org.webosinternals.preware_default"
+        ] 
+    },
+    {
+        "title" : "prefs",
+        "items" : [
+            "com.palm.app.accounts_default",
+            "com.palm.app.backup_default",
+            "com.palm.app.bluetooth_default",
+            "com.palm.app.dateandtime_default",
+            "com.palm.app.deviceinfo_default",
+            "com.palm.app.exhibitionpreferences_default",
+            "com.palm.app.help_default",
+            "com.palm.app.searchpreferences_default",
+            "com.palm.app.location_default",
+            "com.palm.app.printmanager_default",
+            "com.palm.app.languagepicker_default",
+            "com.palm.app.screenlock_default",
+            "org.webosports.app.settings_default",
+            "org.webosinternals.tweaks_default",
+            "org.webosports.cdav.app_default",
+            "org.webosports.app.testr_default",
+            "sdl2_opengles1_test_default",
+            "sdl2_opengles2_test_default",
+            "com.palm.app.swmanager_default",
+            "com.palm.app.soundsandalerts_default",
+            "com.palm.app.updates_default",
+            "com.palm.app.textassist_default",
+            "com.palm.app.vpn_default",
+            "com.palm.app.wifi_default",
+            "org.webosports.app.settings.bluetooth_default",
+            "org.webosports.app.settings.dateandtime_default",
+            "org.webosports.app.settings.deviceinfo_default",
+            "org.webosports.app.settings.exhibitionpreferences_default",
+            "org.webosports.app.settings.help_default",
+            "org.webosports.app.settings.searchpreferences_default",
+            "org.webosports.app.settings.location_default",
+            "org.webosports.app.settings.languagepicker_default",
+            "org.webosports.app.settings.screenlock_default",
+            "org.webosports.app.settings.soundsandalerts_default",
+            "org.webosports.app.settings.textassist_default",
+            "org.webosports.app.settings.vpn_default",
+            "org.webosports.app.settings.wifi_default"
+        ] 
+    }
+]


### PR DESCRIPTION
Used to be in luna-sysmgr, now moving it to luna-init and adding our new QML Settings Apps so they will appear in Prefs tab.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>