### PR TITLE
default-launcher-page-layout.json: Update Preware name

### DIFF
--- a/files/conf/default-launcher-page-layout.json
+++ b/files/conf/default-launcher-page-layout.json
@@ -21,7 +21,7 @@
     {
         "title" : "downloads",
         "items" : [
-            "org.webosinternals.preware_default"
+            "org.webosports.app.preware_default"
         ] 
     },
     {


### PR DESCRIPTION
Update rebranding of Preware after ACG migration.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>