### PR TITLE
luna-init: Switch to com.webos.app.enactbrowser

### DIFF
--- a/files/conf/command-resource-handlers.json
+++ b/files/conf/command-resource-handlers.json
@@ -22,7 +22,7 @@
 
 		{ "extn":"ipk", "mime":"application/vnd.webos.ipk", "appId":"org.webosports.app.preware", "streamable":false },
 		{ "extn":"pdf", "mime":"pdf", "appId":"org.webosports.app.pdf", "streamable":false },
-		{ "extn":"svg", "mime":"image/svg", "appId":"org.webosports.app.browser", "streamable":false },
+		{ "extn":"svg", "mime":"image/svg", "appId":"com.webos.app.enactbrowser", "streamable":false },
 		{ "extn":"png", "mime":"image/png", "appId":"org.webosports.app.photos", "streamable":false }
 	],
 
@@ -34,8 +34,8 @@
 		{ "url":"^contact:", "appId":"org.webosports.app.contacts" },
 		{ "url":"^chatWith:", "appId":"org.webosports.app.messaging" },
 		{ "url":"^opencontact:", "appId":"org.webosports.app.contacts" },
-		{ "url":"^https?:", "appId":"org.webosports.app.browser"},
-		{ "url":"^data:", "appId":"org.webosports.app.browser"},
+		{ "url":"^https?:", "appId":"com.webos.app.enactbrowser"},
+		{ "url":"^data:", "appId":"com.webos.app.enactbrowser"},
 		{ "url":"^tel:", "appId":"org.webosports.app.phone"},
 		{ "url":"^mobi:", "appId":"com.palm.app.videoplayer"},
 		{ "url":"^mapto:", "appId":"org.webosports.app.maps"},

--- a/files/conf/default-dock-positions.json
+++ b/files/conf/default-dock-positions.json
@@ -2,7 +2,7 @@
 	{
 		"type": "tablet",
 		"items": [
-				"org.webosports.app.browser_default",
+				"com.webos.app.enactbrowser_default",
 				"com.palm.app.email_default",
 				"com.palm.app.calendar_default",
 				"org.webosports.app.messaging_default",

--- a/files/conf/default-launcher-page-layout.json
+++ b/files/conf/default-launcher-page-layout.json
@@ -2,7 +2,7 @@
     {
         "title" : "apps",
         "items" : [
-            "org.webosports.app.browser_default",
+            "com.webos.app.enactbrowser_default",
             "com.palm.app.email_default",
             "com.palm.app.calendar_default",
             "org.webosports.app.messaging_default",


### PR DESCRIPTION
Since we no longer have org.webosports.app.browser in the image.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
